### PR TITLE
P3) VSCode Extension: Add a Refresh Button to Tree View #4107

### DIFF
--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -14,7 +14,7 @@ import {
   WebhookHandleSpecification,
 } from '../../types';
 import { getSpecs } from '../../api';
-import { loadConfig } from '../../config';
+import { loadConfig, addOrUpdateConfig } from '../../config';
 import {
   generateContextDataFile,
   getContextDataFileContent,
@@ -382,6 +382,9 @@ const generate = async ({
 
   try {
     specs = await getSpecs(contexts, names, functionIds, noTypes);
+    if (contexts) {
+      addOrUpdateConfig(polyPath, 'LAST_GENERATE_CONTEXTS_USED', contexts?.join(','));
+    }
   } catch (error) {
     showErrGettingSpecs(error);
     return;

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,11 +8,17 @@ const getPolyConfigDirPath = (polyPath: string) =>
 const getPolyConfigFilePath = (polyPath: string) =>
   `${getPolyConfigDirPath(polyPath)}/.config.env`;
 
-export const loadConfig = (polyPath: string) => {
+export const loadConfig = (polyPath: string): Record<string, string> | undefined => {
   const configFilePath = getPolyConfigFilePath(polyPath);
   if (fs.existsSync(configFilePath)) {
-    dotenv.config({ path: configFilePath, override: process.env.CONFIG_ENV_PATH_PRIORITY === 'true' });
+    const result = dotenv.config({
+      path: configFilePath,
+      override: process.env.CONFIG_ENV_PATH_PRIORITY === 'true',
+    });
+
+    return result.parsed;
   }
+  return undefined;
 };
 
 export const saveConfig = (polyPath: string, config: Record<string, string>) => {
@@ -23,4 +29,12 @@ export const saveConfig = (polyPath: string, config: Record<string, string>) => 
       .map(([key, value]) => `${key}=${value}`)
       .join('\n'),
   );
+};
+
+export const addOrUpdateConfig = (polyPath: string, key: string, value: string) => {
+  const existingConfig = loadConfig(polyPath) ?? {};
+
+  existingConfig[key] = value;
+
+  saveConfig(polyPath, existingConfig);
 };


### PR DESCRIPTION
Issue solved: https://github.com/polyapi/poly-alpha/issues/4107

- if successfully generate context run it will saved to a key LAST_GENERATE_CONTEXTS_USED
- load config now can return value
- Add or Update config function added