### PR TITLE
Windows glide duplicate deployables fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "polyapi",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "polyapi",
-      "version": "0.24.4",
+      "version": "0.24.5",
       "license": "MIT",
       "dependencies": {
         "@guanghechen/helper-string": "4.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polyapi",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "description": "Poly is a CLI tool to help create and manage your Poly definitions.",
   "license": "MIT",
   "repository": {

--- a/src/deployables.ts
+++ b/src/deployables.ts
@@ -183,7 +183,7 @@ export const getAllDeployableFilesWindows = ({
   const excludeCommand = excludePattern
     ? ` | findstr /V /I "${excludePattern}"`
     : '';
-  const searchCommand = ` | findstr /M /I /S /F:/ ${pattern} *.*`;
+  const searchCommand = ` | findstr /M /I /F:/ ${pattern}`;
 
   let result: string[] = [];
   for (const dir of includeDirs) {
@@ -195,7 +195,7 @@ export const getAllDeployableFilesWindows = ({
         : includeFilesOrExtensions
           .map((f) => (f.includes('.') ? f : `${dir}*.${f}`))
           .join(' ');
-    const dirCommand = `dir ${includePattern} /S /P /B > NUL`;
+    const dirCommand = `dir ${includePattern} /S /P /B `;
     const fullCommand = `${dirCommand}${excludeCommand}${searchCommand}`;
     try {
       const output = shell.exec(fullCommand, {silent:true}).toString('utf8');


### PR DESCRIPTION
Changed windows command for finding deployables to ensure that the same file is not found multiple times