### PR TITLE
Only warn if POLY_API_BASE_URL is http in production environment

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -48,11 +48,12 @@ const nodeEnv = process.env.NODE_ENV;
 const isDevEnv = nodeEnv === 'development';
 
 const getApiBaseURL = () => {
-  if (isDevEnv) {
-    return process.env.POLY_API_BASE_URL;
-  } else {
-    return process.env.POLY_API_BASE_URL.replace(/^http:/, 'https://');
+  if (!isDevEnv && process.env.POLY_API_BASE_URL?.startsWith('http:')) {
+    console.warn(
+      `Using POLY_API_BASE_URL with http in production environment is not recommended. If you are using a custom base URL, please make sure it is using https.`,
+    );
   }
+  return process.env.POLY_API_BASE_URL;
 };
 
 const getApiHeaders = () => ({


### PR DESCRIPTION
Resolves [#6258](https://github.com/polyapi/poly-alpha/issues/6258) by decoupling NODE_ENV=production from the mandatory HTTPS requirement for POLY_API_BASE_URL.

Previously, setting the environment to production forced a check for an HTTPS base URL. This prevented us from leveraging Node.js production optimizations inside the cluster, where services communicate over HTTP