### PR TITLE
add better logging for api func execute errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polyapi",
-  "version": "0.26.4",
+  "version": "0.26.5",
   "description": "Poly is a CLI tool to help create and manage your Poly definitions.",
   "license": "MIT",
   "repository": {

--- a/templates/api-index.js
+++ b/templates/api-index.js
@@ -74,12 +74,10 @@ const executeApiFunction = (id, clientID, polyCustom, requestArgs) => {
     ).then(({ headers, data }) => {
       polyHeaders = headers;
       if (data && (data.status < 200 || data.status >= 300) && process.env.LOGS_ENABLED) {
-        let responseData = data.data;
-        try {
-          responseData = JSON.stringify(data.data);
-        } catch (err) {}
+        const responseData = safeStringify(data.data);
         requestArgs = scrub(requestArgs)
-        console.error('Error executing api function with id:', id, 'Status code:', data.status, 'Request data:', scrubbedArgs, 'Response data:', responseData);
+        const requestData = safeStringify(requestArgs);
+        console.error('Error direct executing api function with id:', id, 'Status code:', data.status, 'Request data:', requestData, 'Response data:', responseData);
       }
 
       serverPreperationTimeMs = Number(polyHeaders['x-poly-execution-duration']);
@@ -97,8 +95,10 @@ const executeApiFunction = (id, clientID, polyCustom, requestArgs) => {
       })
     }).then(({ headers, data, status }) => {
       if (status && (status < 200 || status >= 300) && process.env.LOGS_ENABLED) {
+        const responseData = safeStringify(data.data);
         requestArgs = scrub(requestArgs)
-        console.error('Error direct executing api function with id:', id, 'Status code:', status, 'Request data:', requestArgs, 'Response data:', data.data);
+        const requestData = safeStringify(requestArgs);
+        console.error('Error direct executing api function with id:', id, 'Status code:', data.status, 'Request data:', requestData, 'Response data:', responseData);
       }
       const apiExecutionTimeMs = Date.now() - requestApiStartTime;
       return {
@@ -125,12 +125,10 @@ const executeApiFunction = (id, clientID, polyCustom, requestArgs) => {
     }
   ).then(({ headers, data }) => {
     if (data && (data.status < 200 || data.status >= 300) && process.env.LOGS_ENABLED) {
-      let responseData = data.data;
-      try {
-        responseData = JSON.stringify(data.data);
-      } catch (err) {}
+      const responseData = safeStringify(data.data);
       requestArgs = scrub(requestArgs)
-      console.error('Error executing api function with id:', id, 'Status code:', data.status, 'Request data:', requestArgs, 'Response data:', responseData);
+      const requestData = safeStringify(requestArgs);
+      console.error('Error executing api function with id:', id, 'Status code:', data.status, 'Request data:', requestData, 'Response data:', responseData);
     }
     const serverExecutionTimeMs = Number(headers['x-poly-execution-duration']);
     const roundTripNetworkLatencyMs = Date.now() - requestServerStartTime - serverExecutionTimeMs;
@@ -142,6 +140,14 @@ const executeApiFunction = (id, clientID, polyCustom, requestArgs) => {
       }
     };
   }).catch(handleError);
+}
+
+function safeStringify(obj) {
+  try {
+    return JSON.stringify(obj, null, 2);
+  } catch (err) {
+    // silently swallow error and just log input
+  }
 }
 
 module.exports = (clientID, polyCustom) => functions.reduce(


### PR DESCRIPTION
Ticket:

https://github.com/polyapi/poly-alpha/issues/6529

I THINK my code is functionally identical to what was there before

just with an extra stringify surrounded by try/catch on the requestArgs

so that's low risk if true

however this feels like it would totally break all SDK API functions if I screwed it up

so that's high risk

@aarongoin feel free to veto if this one can go in R32 or not. I feel like it's just safe enough but I'm also open to postponing to R33