### PR TITLE
dont include node libs in requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polyapi",
-  "version": "0.26.9",
+  "version": "0.26.10",
   "description": "Poly is a CLI tool to help create and manage your Poly definitions.",
   "license": "MIT",
   "repository": {

--- a/src/transpiler.ts
+++ b/src/transpiler.ts
@@ -459,7 +459,9 @@ export const getDependencies = async (
   });
 
   const dependencies = Array.from(importedLibraries).filter(
-    (library) => !EXCLUDED_REQUIREMENTS.includes(library),
+    (library) =>
+      // exclude already included libraries and Node.js built-in modules
+      !EXCLUDED_REQUIREMENTS.includes(library) && !library.startsWith('node:')
   );
   const externalDependencies: Record<string, string> = {};
   const internalDependencies: Record<string, InternalDependencyReference[]> =


### PR DESCRIPTION
As a developer ~~blindly copypastaing code from AI into my SFX~~ using modern software engineering techniques I sometimes produce code like:

```
from { execAsync } from "node:child_process"
```

this code right now blows up because our SFX does not recognize it as a node library and tries to include `node:child_process` as a requirement which  doesn't work brah!

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215941085529830
  - https://app.asana.com/0/0/1215941085529840